### PR TITLE
refactor: migrate database layer from sqlite3 to SQLAlchemy ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ MONO_PUBLIC_KEY=your_mono_public_key_here
 MONO_WEBHOOK_SECRET=your_webhook_secret_here
 MONO_BASE_URL=https://api.withmono.com
 MONO_ENVIRONMENT=sandbox  # or 'production'
+DATABASE_URL=postgres or mysql or just leave it out to use sqlite as default
 ```
 
 ## 🚀 Usage

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ mypy mono_banking_mcp/ --ignore-missing-imports
 
 ## Contributing
 
-Contributions to the Mono Banking MCP Server are welcome! For questions or help getting started, please open an issue.
+Contributions to the Mono Banking MCP Server are welcome! For questions or help getting started, please open an issue. 
 
 **Quick Start for Contributors:**
 ```bash

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -130,7 +130,7 @@ class MonoBankingDB:
 
             with self.database() as db:
                 webhook_event = WebhookEvent(
-                    event_type=event_type, account_id=account_id, data=json.dumps(data)
+                    event_type=event_type, account_id=account_id, data=json.dumps(data) 
                 )
                 db.add(webhook_event)
                 db.commit()

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -149,23 +149,23 @@ class MonoBankingDB:
                     existing_txn = db.get(Transaction, txn.get("_id"))
                     if existing_txn:
                         existing_txn.account_id = account_id
-                        existing_txn.amount = txn.get("amount")
-                        existing_txn.type = txn.get("type")
+                        existing_txn.amount = int(txn.get("amount", 0) or 0)
+                        existing_txn.type = str(txn.get("type", ""))
                         existing_txn.description = txn.get("narration")
                         existing_txn.reference = txn.get("reference")
-                        existing_txn.date = txn.get("date")
-                        existing_txn.balance = txn.get("balance")
-                        existing_txn.category = txn.get("category")
+                        existing_txn.date = str(txn.get("date", ""))
+                        existing_txn.balance = int(txn.get("balance", 0) or 0)
+                        existing_txn.category = txn.get("category")                        
                     else:
                         transaction = Transaction(
                             id=txn.get("_id"),
                             account_id=account_id,
-                            amount=txn.get("amount"),
-                            type=txn.get("type"),
+                            amount=int(txn.get("amount", 0) or 0),
+                            type=str(txn.get("type", "")),
                             description=txn.get("narration"),
                             reference=txn.get("reference"),
-                            date=txn.get("date"),
-                            balance=txn.get("balance"),
+                            date=str(txn.get("date", "")),
+                            balance=int(txn.get("balance", 0) or 0),
                             category=txn.get("category"),
                         )
                         db.add(transaction)

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -176,7 +176,7 @@ class MonoBankingDB:
             return False
           
     def get_recent_transactions(
-        self, account_id: str, limit: int = 10
+        self, account_id: str, limit: int = 10 
     ) -> List[Dict[str, Any]]:
         """get recent transactions from database"""
         try:

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime
 from typing import Dict, Any, List, Optional
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
-from sqlalchemy import create_engine, func, inspect
+from sqlalchemy import create_engine, inspect
 
 
 class Base(DeclarativeBase):

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -96,7 +96,6 @@ class MonoBankingDB:
         except Exception as e:
             print(f"error storing account: {e}")
             return False
-
           
     def get_account(self, account_id: str) -> Optional[Dict[str, Any]]:
         """retrieve account by id"""
@@ -122,7 +121,6 @@ class MonoBankingDB:
         except Exception as e:
             print(f"error getting account: {e}")
             return None
-
           
     def store_webhook_event(
         self, event_type: str, account_id: str, data: Dict[str, Any]
@@ -140,7 +138,6 @@ class MonoBankingDB:
         except Exception as e:
             print(f"error storing webhook event: {e}")
             return False
-
           
     def store_transactions(
         self, account_id: str, transactions: List[Dict[str, Any]]
@@ -177,7 +174,6 @@ class MonoBankingDB:
         except Exception as e:
             print(f"error storing transactions: {e}")
             return False
-
           
     def get_recent_transactions(
         self, account_id: str, limit: int = 10
@@ -212,7 +208,6 @@ class MonoBankingDB:
             print(f"error getting transactions: {e}")
             return []
 
-          
     def remove_account(self, account_id: str) -> bool:
         """remove account and related data"""
         try:

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -1,165 +1,231 @@
 """
 Simple database layer for storing webhook events and account data.
 """
-import sqlite3
+
 import json
 from datetime import datetime
 from typing import Dict, Any, List, Optional
-from pathlib import Path
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
+from sqlalchemy import create_engine, func, inspect
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Account(Base):
+    __tablename__ = "accounts"
+
+    id: Mapped[str] = mapped_column(primary_key=True)
+    customer_id: Mapped[str]
+    account_number: Mapped[str]
+    account_name: Mapped[str]
+    bank_name: Mapped[str]
+    bank_code: Mapped[str]
+    account_type: Mapped[str]
+    currency: Mapped[str]
+    bvn: Mapped[Optional[str]]
+    status: Mapped[str] = mapped_column(default="active")
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class WebhookEvent(Base):
+    __tablename__ = "webhook_events"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    event_type: Mapped[str]
+    account_id: Mapped[Optional[str]]
+    data: Mapped[str]
+    processed: Mapped[bool] = mapped_column(default=False)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    id: Mapped[str] = mapped_column(primary_key=True)
+    account_id: Mapped[str]
+    amount: Mapped[int]
+    type: Mapped[str]
+    description: Mapped[Optional[str]]
+    reference: Mapped[Optional[str]]
+    date: Mapped[str]
+    balance: Mapped[int]
+    category: Mapped[Optional[str]]
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+
 
 class MonoBankingDB:
     """lightweight database for mono banking data"""
-    
-    def __init__(self, db_path: str = "mono_banking.db"):
-        self.db_path = Path(db_path)
-        self.init_database()
-    
-    def init_database(self):
-        """create tables if they don't exist"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.executescript("""
-                CREATE TABLE IF NOT EXISTS accounts (
-                    id TEXT PRIMARY KEY,
-                    customer_id TEXT,
-                    account_number TEXT,
-                    account_name TEXT,
-                    bank_name TEXT,
-                    bank_code TEXT,
-                    account_type TEXT,
-                    currency TEXT,
-                    bvn TEXT,
-                    status TEXT DEFAULT 'active',
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                );
-                
-                CREATE TABLE IF NOT EXISTS webhook_events (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    event_type TEXT NOT NULL,
-                    account_id TEXT,
-                    data TEXT NOT NULL,
-                    processed BOOLEAN DEFAULT FALSE,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                );
-                
-                CREATE TABLE IF NOT EXISTS transactions (
-                    id TEXT PRIMARY KEY,
-                    account_id TEXT NOT NULL,
-                    amount INTEGER,
-                    type TEXT,
-                    description TEXT,
-                    reference TEXT,
-                    date TEXT,
-                    balance INTEGER,
-                    category TEXT,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    FOREIGN KEY (account_id) REFERENCES accounts (id)
-                );
-                
-                CREATE INDEX IF NOT EXISTS idx_webhook_events_type ON webhook_events(event_type);
-                CREATE INDEX IF NOT EXISTS idx_transactions_account ON transactions(account_id);
-            """)
-    
+
+    def __init__(self, db_url: str, **kwargs: Any):
+        try:
+
+            db_engine = create_engine(db_url, **kwargs)
+        except Exception as e:
+            raise ValueError(
+                f"Failed to create database engine for URL '{db_url}'"
+            ) from e
+        self.db_engine = db_engine
+        self.Session = sessionmaker(bind=self.db_engine)
+        inspector = inspect(self.db_engine)
+        existing_tables = inspector.get_table_names()
+
+        if "accounts" not in existing_tables:
+            Base.metadata.create_all(self.db_engine)
+        if "webhook_events" not in existing_tables:
+            Base.metadata.create_all(self.db_engine)
+        if "transactions" not in existing_tables:
+            Base.metadata.create_all(self.db_engine)
+
     def store_account(self, account_data: Dict[str, Any]) -> bool:
         """store or update account information"""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.execute("""
-                    INSERT OR REPLACE INTO accounts 
-                    (id, customer_id, account_number, account_name, bank_name, 
-                     bank_code, account_type, currency, bvn, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """, (
-                    account_data.get("id"),
-                    account_data.get("customer_id"),
-                    account_data.get("account_number"),
-                    account_data.get("account_name"),
-                    account_data.get("bank_name"),
-                    account_data.get("bank_code"),
-                    account_data.get("account_type"),
-                    account_data.get("currency"),
-                    account_data.get("bvn"),
-                    datetime.now().isoformat()
-                ))
+            with self.Session() as db:
+                account = db.get(Account, account_data.get("id"))
+                if not account:
+                    account = Account(**account_data)
+                    db.add(account)
+                else:
+                    for key, value in account_data.items():
+                        setattr(account, key, value)
+                db.commit()
+
             return True
         except Exception as e:
             print(f"error storing account: {e}")
             return False
-    
+
     def get_account(self, account_id: str) -> Optional[Dict[str, Any]]:
         """retrieve account by id"""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.row_factory = sqlite3.Row
-                cursor = conn.execute(
-                    "SELECT * FROM accounts WHERE id = ?", (account_id,)
-                )
-                row = cursor.fetchone()
-                return dict(row) if row else None
+            with self.Session() as db:
+                account = db.get(Account, account_id)
+                if account:
+                    return {
+                        "id": account.id,
+                        "customer_id": account.customer_id,
+                        "account_number": account.account_number,
+                        "account_name": account.account_name,
+                        "bank_name": account.bank_name,
+                        "bank_code": account.bank_code,
+                        "account_type": account.account_type,
+                        "currency": account.currency,
+                        "bvn": account.bvn,
+                        "status": account.status,
+                        "created_at": account.created_at,
+                        "updated_at": account.updated_at,
+                    }
+                return None
         except Exception as e:
             print(f"error getting account: {e}")
             return None
-    
-    def store_webhook_event(self, event_type: str, account_id: str, data: Dict[str, Any]) -> bool:
+
+    def store_webhook_event(
+        self, event_type: str, account_id: str, data: Dict[str, Any]
+    ) -> bool:
         """store webhook event for processing"""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.execute("""
-                    INSERT INTO webhook_events (event_type, account_id, data)
-                    VALUES (?, ?, ?)
-                """, (event_type, account_id, json.dumps(data)))
+            with self.Session() as db:
+                webhook_event = WebhookEvent(
+                    event_type=event_type, account_id=account_id, data=json.dumps(data)
+                )
+                db.add(webhook_event)
+                db.commit()
             return True
         except Exception as e:
             print(f"error storing webhook event: {e}")
             return False
-    
-    def store_transactions(self, account_id: str, transactions: List[Dict[str, Any]]) -> bool:
+
+    def store_transactions(
+        self, account_id: str, transactions: List[Dict[str, Any]]
+    ) -> bool:
         """store transaction history"""
         try:
-            with sqlite3.connect(self.db_path) as conn:
+            with self.Session() as db:
                 for txn in transactions:
-                    conn.execute("""
-                        INSERT OR REPLACE INTO transactions 
-                        (id, account_id, amount, type, description, reference, date, balance, category)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        txn.get("_id"),
-                        account_id,
-                        txn.get("amount"),
-                        txn.get("type"),
-                        txn.get("narration"),
-                        txn.get("reference"),
-                        txn.get("date"),
-                        txn.get("balance"),
-                        txn.get("category")
-                    ))
+                    existing_txn = db.get(Transaction, txn.get("_id"))
+                    if existing_txn:
+                        existing_txn.account_id = account_id
+                        existing_txn.amount = txn.get("amount")
+                        existing_txn.type = txn.get("type")
+                        existing_txn.description = txn.get("narration")
+                        existing_txn.reference = txn.get("reference")
+                        existing_txn.date = txn.get("date")
+                        existing_txn.balance = txn.get("balance")
+                        existing_txn.category = txn.get("category")
+                    else:
+                        transaction = Transaction(
+                            id=txn.get("_id"),
+                            account_id=account_id,
+                            amount=txn.get("amount"),
+                            type=txn.get("type"),
+                            description=txn.get("narration"),
+                            reference=txn.get("reference"),
+                            date=txn.get("date"),
+                            balance=txn.get("balance"),
+                            category=txn.get("category"),
+                        )
+                        db.add(transaction)
+                db.commit()
             return True
         except Exception as e:
             print(f"error storing transactions: {e}")
             return False
-    
-    def get_recent_transactions(self, account_id: str, limit: int = 10) -> List[Dict[str, Any]]:
+
+    def get_recent_transactions(
+        self, account_id: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """get recent transactions from database"""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.row_factory = sqlite3.Row
-                cursor = conn.execute("""
-                    SELECT * FROM transactions 
-                    WHERE account_id = ? 
-                    ORDER BY date DESC 
-                    LIMIT ?
-                """, (account_id, limit))
-                return [dict(row) for row in cursor.fetchall()]
+            with self.Session() as db:
+                transactions = (
+                    db.query(Transaction)
+                    .filter(Transaction.account_id == account_id)
+                    .order_by(Transaction.date.desc())
+                    .limit(limit)
+                    .all()
+                )
+
+                return [
+                    {
+                        "id": txn.id,
+                        "account_id": txn.account_id,
+                        "amount": txn.amount,
+                        "type": txn.type,
+                        "description": txn.description,
+                        "reference": txn.reference,
+                        "date": txn.date,
+                        "balance": txn.balance,
+                        "category": txn.category,
+                        "created_at": txn.created_at,
+                    }
+                    for txn in transactions
+                ]
         except Exception as e:
             print(f"error getting transactions: {e}")
             return []
-    
+
     def remove_account(self, account_id: str) -> bool:
         """remove account and related data"""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.execute("DELETE FROM accounts WHERE id = ?", (account_id,))
-                conn.execute("DELETE FROM transactions WHERE account_id = ?", (account_id,))
+            with self.Session() as db:
+                account = db.get(Account, account_id)
+                if account:
+                    db.delete(account)
+
+                transactions = (
+                    db.query(Transaction)
+                    .filter(Transaction.account_id == account_id)
+                    .all()
+                )
+                for txn in transactions:
+                    db.delete(txn)
+
+                db.commit()
             return True
         except Exception as e:
             print(f"error removing account: {e}")

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -79,7 +79,6 @@ class MonoBankingDB:
             Base.metadata.create_all(self.db_engine)
         if "transactions" not in existing_tables:
             Base.metadata.create_all(self.db_engine)
-            
 
     def store_account(self, account_data: Dict[str, Any]) -> bool:
         """store or update account information"""

--- a/mono_banking_mcp/database.py
+++ b/mono_banking_mcp/database.py
@@ -70,7 +70,7 @@ class MonoBankingDB:
                 f"Failed to create database engine for URL '{db_url}'"
             ) from e
         self.db_engine = db_engine
-        self.Session = sessionmaker(bind=self.db_engine)
+        self.database = sessionmaker(bind=self.db_engine)
         inspector = inspect(self.db_engine)
         existing_tables = inspector.get_table_names()
 
@@ -84,7 +84,7 @@ class MonoBankingDB:
     def store_account(self, account_data: Dict[str, Any]) -> bool:
         """store or update account information"""
         try:
-            with self.Session() as db:
+            with self.database() as db:
                 account = db.get(Account, account_data.get("id"))
                 if not account:
                     account = Account(**account_data)
@@ -102,7 +102,7 @@ class MonoBankingDB:
     def get_account(self, account_id: str) -> Optional[Dict[str, Any]]:
         """retrieve account by id"""
         try:
-            with self.Session() as db:
+            with self.database() as db:
                 account = db.get(Account, account_id)
                 if account:
                     return {
@@ -129,7 +129,7 @@ class MonoBankingDB:
     ) -> bool:
         """store webhook event for processing"""
         try:
-            with self.Session() as db:
+            with self.database() as db:
                 webhook_event = WebhookEvent(
                     event_type=event_type, account_id=account_id, data=json.dumps(data)
                 )
@@ -145,7 +145,7 @@ class MonoBankingDB:
     ) -> bool:
         """store transaction history"""
         try:
-            with self.Session() as db:
+            with self.database() as db:
                 for txn in transactions:
                     existing_txn = db.get(Transaction, txn.get("_id"))
                     if existing_txn:
@@ -181,7 +181,7 @@ class MonoBankingDB:
     ) -> List[Dict[str, Any]]:
         """get recent transactions from database"""
         try:
-            with self.Session() as db:
+            with self.database() as db:
                 transactions = (
                     db.query(Transaction)
                     .filter(Transaction.account_id == account_id)
@@ -212,7 +212,7 @@ class MonoBankingDB:
     def remove_account(self, account_id: str) -> bool:
         """remove account and related data"""
         try:
-            with self.Session() as db:
+            with self.database() as db:
                 account = db.get(Account, account_id)
                 if account:
                     db.delete(account)

--- a/mono_banking_mcp/webhook_server.py
+++ b/mono_banking_mcp/webhook_server.py
@@ -124,7 +124,7 @@ async def handle_account_updated(data: Dict[str, Any]):
         existing_account.update({
             "status": data_status,
             "bank_name": account_info.get("institution", {}).get("name"),
-            "bank_code": account_info.get("institution", {}).get("bankCode"),
+            "bank_code": account_info.get("institution", {}).get("bankCode")
         })
         db.store_account(existing_account)
 

--- a/mono_banking_mcp/webhook_server.py
+++ b/mono_banking_mcp/webhook_server.py
@@ -1,7 +1,9 @@
 """
 Mono Banking Webhook Server for handling real-time events.
 """
+
 import os
+
 import hmac
 import hashlib
 import json
@@ -11,34 +13,36 @@ from fastapi.responses import JSONResponse
 import uvicorn
 from dotenv import load_dotenv
 from .database import MonoBankingDB
+from decouple import config as decouple_config
 
 load_dotenv()
 
 app = FastAPI(title="Mono Banking Webhooks", version="1.0.0")
-db = MonoBankingDB()
+db_url = decouple_config("DATABASE_URL", default="sqlite:///./mono_banking.db")
+db = MonoBankingDB(db_url=db_url)
 
 # get webhook secret from environment
 WEBHOOK_SECRET = os.getenv("MONO_WEBHOOK_SECRET")
 
+
 def verify_webhook_signature(payload: bytes, signature: str) -> bool:
-     """verify webhook signature using HMAC-SHA256"""
-     if not WEBHOOK_SECRET:
-         return False
-     
-     if not signature:
-         return False
-     
-     expected_signature = hmac.new(
-         WEBHOOK_SECRET.encode(),
-         payload,
-         hashlib.sha256
-     ).hexdigest()
-     
-     # Ensure both signatures are the same length to prevent timing attacks
-     if len(signature) != len(expected_signature):
-         return False
-     
-     return hmac.compare_digest(signature, expected_signature)
+    """verify webhook signature using HMAC-SHA256"""
+    if not WEBHOOK_SECRET:
+        return False
+
+    if not signature:
+        return False
+
+    expected_signature = hmac.new(
+        WEBHOOK_SECRET.encode(), payload, hashlib.sha256
+    ).hexdigest()
+
+    # Ensure both signatures are the same length to prevent timing attacks
+    if len(signature) != len(expected_signature):
+        return False
+
+    return hmac.compare_digest(signature, expected_signature)
+
 
 @app.post("/mono/webhook")
 async def handle_webhook(request: Request):
@@ -46,27 +50,26 @@ async def handle_webhook(request: Request):
     try:
         # get raw payload for signature verification
         payload = await request.body()
-        
+
         # verify webhook signature
         signature = request.headers.get("mono-webhook-secret", "")
         if not verify_webhook_signature(payload, signature):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="invalid webhook signature"
+                detail="invalid webhook signature",
             )
-        
+
         # parse json payload
         try:
             event_data = json.loads(payload.decode())
         except json.JSONDecodeError:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="invalid json payload"
+                status_code=status.HTTP_400_BAD_REQUEST, detail="invalid json payload"
             )
-        
+
         event_type = event_data.get("event")
         data = event_data.get("data", {})
-        
+
         # handle different webhook events
         if event_type == "mono.events.account_connected":
             await handle_account_connected(data)
@@ -78,17 +81,18 @@ async def handle_webhook(request: Request):
             await handle_job_update(data)
         else:
             print(f"unknown webhook event: {event_type}")
-        
+
         return JSONResponse({"status": "success"}, status_code=200)
-        
+
     except HTTPException:
         raise
     except Exception as e:
         print(f"webhook error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="internal server error"
+            detail="internal server error",
         )
+
 
 async def handle_account_connected(data: Dict[str, Any]):
     """handle account connection event"""
@@ -96,11 +100,7 @@ async def handle_account_connected(data: Dict[str, Any]):
     customer_id = data.get("customer")
 
     # store account in database
-    account_data = {
-        "id": account_id,
-        "customer_id": customer_id,
-        "status": "connected"
-    }
+    account_data = {"id": account_id, "customer_id": customer_id, "status": "connected"}
 
     if db.store_account(account_data):
         print(f"account connected and stored: {account_id}")
@@ -109,6 +109,7 @@ async def handle_account_connected(data: Dict[str, Any]):
 
     # store webhook event
     db.store_webhook_event("account_connected", account_id, data)
+
 
 async def handle_account_updated(data: Dict[str, Any]):
     """handle account update event"""
@@ -123,12 +124,13 @@ async def handle_account_updated(data: Dict[str, Any]):
         existing_account.update({
             "status": data_status,
             "bank_name": account_info.get("institution", {}).get("name"),
-            "bank_code": account_info.get("institution", {}).get("bankCode")
+            "bank_code": account_info.get("institution", {}).get("bankCode"),
         })
         db.store_account(existing_account)
 
     print(f"account updated: {account_id}, status: {data_status}")
     db.store_webhook_event("account_updated", account_id, data)
+
 
 async def handle_account_unlinked(data: Dict[str, Any]):
     """handle account unlink event"""
@@ -143,6 +145,7 @@ async def handle_account_unlinked(data: Dict[str, Any]):
 
     db.store_webhook_event("account_unlinked", account_id, data)
 
+
 async def handle_job_update(data: Dict[str, Any]):
     """handle job status update"""
     account_id = data.get("account")
@@ -155,14 +158,17 @@ async def handle_job_update(data: Dict[str, Any]):
     if job_status == "finished":
         print(f"job finished for account {account_id} - ready for data sync")
 
+
 @app.get("/health")
 async def health_check():
     """health check endpoint"""
     return {"status": "healthy", "service": "mono-banking-webhooks"}
 
+
 def run_webhook_server(host: str = "0.0.0.0", port: int = 8000):
     """run the webhook server"""
     uvicorn.run(app, host=host, port=port)
+
 
 if __name__ == "__main__":
     run_webhook_server()

--- a/mono_banking_mcp/webhook_server.py
+++ b/mono_banking_mcp/webhook_server.py
@@ -121,11 +121,13 @@ async def handle_account_updated(data: Dict[str, Any]):
     # update account status in database
     existing_account = db.get_account(account_id)
     if existing_account:
-        existing_account.update({
-            "status": data_status,
-            "bank_name": account_info.get("institution", {}).get("name"),
-            "bank_code": account_info.get("institution", {}).get("bankCode"),
-        })
+        existing_account.update(
+            {
+                "status": data_status,
+                "bank_name": account_info.get("institution", {}).get("name"),
+                "bank_code": account_info.get("institution", {}).get("bankCode"),
+            }
+        )
         db.store_account(existing_account)
 
     print(f"account updated: {account_id}, status: {data_status}")

--- a/mono_banking_mcp/webhook_server.py
+++ b/mono_banking_mcp/webhook_server.py
@@ -114,7 +114,6 @@ async def handle_account_connected(data: Dict[str, Any]):
         print(f"Invalid account_id in webhook event: {account_id}")
 
 
-
 async def handle_account_updated(data: Dict[str, Any]):
     """handle account update event"""
     account_info = data.get("account", {})
@@ -154,7 +153,6 @@ async def handle_account_unlinked(data: Dict[str, Any]):
         db.store_webhook_event("account_unlinked", account_id, data)
     else:
         print(f"Invalid account_id in webhook event: {account_id}")
-
 
 
 async def handle_job_update(data: Dict[str, Any]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
     "httpx>=0.25.0",
     "python-dotenv>=1.0.0",
     "fastapi>=0.104.0",
-    "uvicorn>=0.24.0"
+    "uvicorn>=0.24.0",
+    "python-decouple>=3.8",
+    "sqlalchemy>=2.0.43",
 ]
 
 

--- a/tests/test_mono_banking.py
+++ b/tests/test_mono_banking.py
@@ -287,7 +287,7 @@ class TestDatabaseIntegration:
         """Test database connection and basic operations."""
         from mono_banking_mcp.database import MonoBankingDB
         
-        db = MonoBankingDB(":memory:")  # Use in-memory database for testing
+        db = MonoBankingDB("sqlite:///:memory:")  # Use in-memory database for testing
         
         # Test storing a webhook event
         event_data = {

--- a/uv.lock
+++ b/uv.lock
@@ -378,6 +378,39 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
+    { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
+    { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -613,7 +646,9 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "python-decouple" },
     { name = "python-dotenv" },
+    { name = "sqlalchemy" },
     { name = "uvicorn" },
 ]
 
@@ -641,8 +676,10 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "python-decouple", specifier = ">=3.8" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "uvicorn", specifier = ">=0.24.0" },
 ]
 provides-extras = ["dev"]
@@ -977,6 +1014,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-decouple"
+version = "3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/97/373dcd5844ec0ea5893e13c39a2c67e7537987ad8de3842fe078db4582fa/python-decouple-3.8.tar.gz", hash = "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f", size = 9612, upload-time = "2023-03-01T19:38:38.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/d4/9193206c4563ec771faf2ccf54815ca7918529fe81f6adb22ee6d0e06622/python_decouple-3.8-py3-none-any.whl", hash = "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66", size = 9947, upload-time = "2023-03-01T19:38:36.015Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1226,6 +1272,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/bc/d59b5d97d27229b0e009bd9098cd81af71c2fa5549c580a0a67b9bed0496/sqlalchemy-2.0.43.tar.gz", hash = "sha256:788bfcef6787a7764169cfe9859fe425bf44559619e1d9f56f5bddf2ebf6f417", size = 9762949, upload-time = "2025-08-11T14:24:58.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/db/20c78f1081446095450bdc6ee6cc10045fce67a8e003a5876b6eaafc5cc4/sqlalchemy-2.0.43-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:20d81fc2736509d7a2bd33292e489b056cbae543661bb7de7ce9f1c0cd6e7f24", size = 2134891, upload-time = "2025-08-11T15:51:13.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0a/3d89034ae62b200b4396f0f95319f7d86e9945ee64d2343dcad857150fa2/sqlalchemy-2.0.43-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:25b9fc27650ff5a2c9d490c13c14906b918b0de1f8fcbb4c992712d8caf40e83", size = 2123061, upload-time = "2025-08-11T15:51:14.319Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/10/2711f7ff1805919221ad5bee205971254845c069ee2e7036847103ca1e4c/sqlalchemy-2.0.43-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6772e3ca8a43a65a37c88e2f3e2adfd511b0b1da37ef11ed78dea16aeae85bd9", size = 3320384, upload-time = "2025-08-11T15:52:35.088Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0e/3d155e264d2ed2778484006ef04647bc63f55b3e2d12e6a4f787747b5900/sqlalchemy-2.0.43-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a113da919c25f7f641ffbd07fbc9077abd4b3b75097c888ab818f962707eb48", size = 3329648, upload-time = "2025-08-11T15:56:34.153Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/81/635100fb19725c931622c673900da5efb1595c96ff5b441e07e3dd61f2be/sqlalchemy-2.0.43-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4286a1139f14b7d70141c67a8ae1582fc2b69105f1b09d9573494eb4bb4b2687", size = 3258030, upload-time = "2025-08-11T15:52:36.933Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ed/a99302716d62b4965fded12520c1cbb189f99b17a6d8cf77611d21442e47/sqlalchemy-2.0.43-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:529064085be2f4d8a6e5fab12d36ad44f1909a18848fcfbdb59cc6d4bbe48efe", size = 3294469, upload-time = "2025-08-11T15:56:35.553Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a2/3a11b06715149bf3310b55a98b5c1e84a42cfb949a7b800bc75cb4e33abc/sqlalchemy-2.0.43-cp312-cp312-win32.whl", hash = "sha256:b535d35dea8bbb8195e7e2b40059e2253acb2b7579b73c1b432a35363694641d", size = 2098906, upload-time = "2025-08-11T15:55:00.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/09/405c915a974814b90aa591280623adc6ad6b322f61fd5cff80aeaef216c9/sqlalchemy-2.0.43-cp312-cp312-win_amd64.whl", hash = "sha256:1c6d85327ca688dbae7e2b06d7d84cfe4f3fffa5b5f9e21bb6ce9d0e1a0e0e0a", size = 2126260, upload-time = "2025-08-11T15:55:02.965Z" },
+    { url = "https://files.pythonhosted.org/packages/41/1c/a7260bd47a6fae7e03768bf66451437b36451143f36b285522b865987ced/sqlalchemy-2.0.43-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e7c08f57f75a2bb62d7ee80a89686a5e5669f199235c6d1dac75cd59374091c3", size = 2130598, upload-time = "2025-08-11T15:51:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/84/8a337454e82388283830b3586ad7847aa9c76fdd4f1df09cdd1f94591873/sqlalchemy-2.0.43-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:14111d22c29efad445cd5021a70a8b42f7d9152d8ba7f73304c4d82460946aaa", size = 2118415, upload-time = "2025-08-11T15:51:17.256Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ff/22ab2328148492c4d71899d62a0e65370ea66c877aea017a244a35733685/sqlalchemy-2.0.43-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21b27b56eb2f82653168cefe6cb8e970cdaf4f3a6cb2c5e3c3c1cf3158968ff9", size = 3248707, upload-time = "2025-08-11T15:52:38.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/29/11ae2c2b981de60187f7cbc84277d9d21f101093d1b2e945c63774477aba/sqlalchemy-2.0.43-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c5a9da957c56e43d72126a3f5845603da00e0293720b03bde0aacffcf2dc04f", size = 3253602, upload-time = "2025-08-11T15:56:37.348Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/61/987b6c23b12c56d2be451bc70900f67dd7d989d52b1ee64f239cf19aec69/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d79f9fdc9584ec83d1b3c75e9f4595c49017f5594fee1a2217117647225d738", size = 3183248, upload-time = "2025-08-11T15:52:39.865Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/29d216002d4593c2ce1c0ec2cec46dda77bfbcd221e24caa6e85eff53d89/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9df7126fd9db49e3a5a3999442cc67e9ee8971f3cb9644250107d7296cb2a164", size = 3219363, upload-time = "2025-08-11T15:56:39.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e4/bd78b01919c524f190b4905d47e7630bf4130b9f48fd971ae1c6225b6f6a/sqlalchemy-2.0.43-cp313-cp313-win32.whl", hash = "sha256:7f1ac7828857fcedb0361b48b9ac4821469f7694089d15550bbcf9ab22564a1d", size = 2096718, upload-time = "2025-08-11T15:55:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a5/ca2f07a2a201f9497de1928f787926613db6307992fe5cda97624eb07c2f/sqlalchemy-2.0.43-cp313-cp313-win_amd64.whl", hash = "sha256:971ba928fcde01869361f504fcff3b7143b47d30de188b11c6357c0505824197", size = 2123200, upload-time = "2025-08-11T15:55:07.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d9/13bdde6521f322861fab67473cec4b1cc8999f3871953531cf61945fad92/sqlalchemy-2.0.43-py3-none-any.whl", hash = "sha256:1681c21dd2ccee222c2fe0bef671d1aef7c504087c9c4e800371cfcc8ac966fc", size = 1924759, upload-time = "2025-08-11T15:39:53.024Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Summary
  - Migrated the entire database layer from raw sqlite3 operations to SQLAlchemy ORM
  - Added proper model definitions for Account, WebhookEvent, and Transaction entities
  - Updated all database operations to use consistent SQLAlchemy session management
  - Fixed configuration and dependency issues
   with this changes user can use any database of their choice without extra configuration which means they are allowed to use etheir postgres mysql or sqllite 
<img width="1920" height="1080" alt="Screenshot 2025-09-06 224056" src="https://github.com/user-attachments/assets/c99d867d-f20a-4438-a444-b9dd8e28ab2b" />
